### PR TITLE
+add hint to package in AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Here are some options:
 	$ sudo cp slacker.php /usr/local/bin/slacker
 	$ slacker
 
+For Arch Linux, there is a [package available in the AUR](https://aur.archlinux.org/packages/slacker/).
+
 Installation Dependencies
 -------------------------
 


### PR DESCRIPTION
I have written a package for Arch Linux, it works like a charm. ;)

You'd actually have the package manager handle the dependencies, not the Makefile. I have also patched the shebang because Slacker wouldn't work with PHP7. =)
